### PR TITLE
[#5] : Eslint no-empty-object-type -> off

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -181,6 +181,7 @@ export default [
             '@typescript-eslint/no-confusing-void-expression': 'off',
             '@typescript-eslint/consistent-return': 'warn',
             '@typescript-eslint/prefer-for-of': 'off',
+            '@typescript-eslint/no-empty-object-type': 'off'
         }
     }
 ];


### PR DESCRIPTION
## Pull Request Overview

This pull request modifies the ESLint configuration to disable the rule that disallows empty object types.

## Related Issue

N/A

## Summary

The change aims to provide flexibility in the codebase by allowing the use of empty object types where necessary.

## Changes

- Disabled the `@typescript-eslint/no-empty-object-type` rule in the ESLint configuration.